### PR TITLE
docs: 8차 코드 리뷰 — 폴더 재정리 및 신규 페이지

### DIFF
--- a/reviews/2026041410_리뷰.md
+++ b/reviews/2026041410_리뷰.md
@@ -1,0 +1,640 @@
+# 프로젝트 코드 리뷰 (8차)
+
+> 리뷰 날짜: 2026-04-14
+> 대상: rawbeef 프로젝트 (SW칸타빌레 - 노래방 차트 + 관리자)
+> 이전 리뷰: [2026033010_리뷰.md](./2026033010_리뷰.md)
+> 브랜치: `docs/8th-code-review`
+
+---
+
+## 0. 이번 리뷰 범위
+
+이번 리뷰는 폴더 구조가 새롭게 정리되고(`woohyun/`·`soyu/` → `src/SWcantabile/`·`src/admin/`),
+신규 페이지(`SWcantabile_introduce.html`)가 추가된 시점을 기준으로 진행했어요.
+
+**이전 리뷰에서 잘 해결된 것들 — 칭찬해요!**
+
+- ~~사이드바 4개 파일 중복 → 이제 `sidebar.js` 컴포넌트 하나로 분리~~ ✅
+- ~~CDN Tailwind와 Vite 혼용 → 모두 Vite + `style.css` import 통일~~ ✅
+- ~~`localStorage` 기반에서 실제 API 연동~~ ✅
+- ~~비어 있던 `rawbeef/` 폴더 정리~~ ✅
+- ~~Header를 컴포넌트(`component/header.js`)로 분리~~ ✅
+- ~~다크 모드 토글(`component/theme.js`) 도입~~ ✅
+
+이전 리뷰 이후 **정말 많이 발전했어요!** 코드 구조가 한층 깔끔해졌습니다.
+이번 리뷰는 그래서 한 단계 더 위의 품질로 끌어올리는 데 집중할게요.
+
+---
+
+## 1. 프로젝트 구조 살펴보기
+
+```
+rawbeef/
+├── index.html                         (루트 → SWcantabile_song.html 리다이렉트)
+├── vite.config.js                     (빌드 설정)
+├── src/
+│   ├── main.js                        (공통 import)
+│   ├── style.css                      (Tailwind 진입점)
+│   ├── component/                     (공통 컴포넌트 ⭐ 신규)
+│   │   ├── api-config.js              (API_BASE 상수)
+│   │   ├── header.js                  (헤더 컴포넌트)
+│   │   └── theme.js                   (다크 모드)
+│   ├── SWcantabile/                   (사용자 페이지)
+│   │   ├── SWcantabile_song.html      (TOP10 차트)
+│   │   ├── SWcantabile_song.js
+│   │   ├── SWcantabile_request.html   (노래 등록 신청)
+│   │   ├── SWcantabile_request.js
+│   │   ├── SWcantabile_introduce.html (소개 페이지 ⭐ 신규)
+│   │   ├── SWcantabile_footer.js
+│   │   └── utils.js
+│   └── admin/                         (관리자 페이지)
+│       ├── admin_open.html            (로그인)
+│       ├── admin_category.html        (카테고리 관리)
+│       ├── admin_category.js
+│       ├── admin_song.html            (노래 관리)
+│       ├── admin_song/                (노래 관리 분리 ⭐)
+│       │   ├── admin_song_main.js     (UI/이벤트)
+│       │   └── admin_song_api.js      (API 호출)
+│       ├── admin_request.html         (신청 관리)
+│       ├── admin_request.js
+│       ├── auth.js                    (토큰 인증)
+│       └── sidebar.js                 (사이드바 컴포넌트)
+└── reviews/
+```
+
+폴더가 **역할별로** 잘 나뉘어 있어요. 특히 `component/`로 공통 요소를 빼낸 것,
+`admin_song/`을 `main.js`와 `api.js`로 나눈 것은 정말 큰 발전이에요.
+
+---
+
+## 2. 잘한 점
+
+### 2-1. 컴포넌트화 (응집도 ↑, 결합도 ↓)
+이전 리뷰에서 가장 크게 지적했던 “HTML마다 헤더/사이드바 복붙” 문제가 깔끔하게 해결됐어요.
+
+```html
+<!-- 이제는 모든 페이지에서 단 두 줄로 끝나요! -->
+<div id="user-header"></div>
+<script src="../component/header.js"></script>
+```
+
+이런 식으로 **관심사를 분리(separation of concerns)** 한 건 큰 발전이에요.
+어떤 페이지에서 헤더 디자인을 바꿔야 할 때, 이제는 `header.js` 한 곳만 고치면 모든 페이지에 반영돼요.
+
+### 2-2. API 호출과 화면 그리기 분리 (admin_song)
+`admin_song_api.js`와 `admin_song_main.js`로 분리한 건 정말 멋진 시도예요!
+
+```js
+// admin_song_api.js — “데이터”만 책임
+const fetchSongs = async (id = null) => { ... };
+const saveSongs  = async (newSongData) => { ... };
+
+// admin_song_main.js — “화면 + 이벤트”만 책임
+const loadSongs = async (id = null) => {
+  const data = await fetchSongs(id);
+  songs = data;
+  renderSongs();
+};
+```
+
+이렇게 나누면 나중에 API 주소가 바뀌어도 `_api.js`만 고치면 돼요.
+**다른 admin 페이지(category, request)도 똑같이 분리하면** 일관성이 더 좋아져요.
+
+### 2-3. XSS 방지 `esc()` 함수
+`SWcantabile/utils.js`에 만들어 둔 `esc()` 함수는 보안적으로 아주 훌륭해요.
+
+```js
+function esc(str) {
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;')...
+}
+```
+
+`innerHTML`로 데이터를 그릴 때 매번 `${esc(item.title)}`로 감싸 주는 습관도 좋아요.
+이걸 안 쓰면 사용자가 제목에 `<script>`를 넣어 공격할 수 있거든요.
+
+### 2-4. 다크 모드 일관성
+`component/theme.js`에서 `localStorage` + 시스템 prefers-color-scheme까지 모두 처리하고 있어요.
+모든 페이지에서 다크/라이트가 자연스럽게 동작하는 건 매우 잘 만든 부분이에요.
+
+### 2-5. URL 파라미터로 상태 공유
+`SWcantabile_song.js`와 `admin_song_main.js`에서 `?category=...`로 카테고리를 URL에 반영하는 건
+사용자가 **새로고침해도 같은 화면**을 볼 수 있게 해 주는 좋은 패턴이에요.
+
+```js
+const params = new URLSearchParams(location.search);
+const categoryName = params.get('category');
+```
+
+### 2-6. 검색·페이지네이션
+`SWcantabile_request.js`의 페이지네이션 그룹 처리(`groupSize = 10`)나
+검색 키워드 enter 처리는 사용자 입장을 잘 고려한 디테일이에요.
+
+---
+
+## 3. 개선하면 좋을 점
+
+### 3-1. `SWcantabile_introduce.html`이 빌드 설정에 빠져 있어요 (중요도: 높음)
+
+**현재 상태:** `vite.config.js`에 신규 페이지가 등록돼 있지 않아요.
+
+```js
+// vite.config.js
+input: {
+  main: resolve(__dirname, 'index.html'),
+  admin_open: ...,
+  admin_category: ...,
+  admin_song: ...,
+  admin_request: ...,
+  SWcantabile_song: ...,
+  SWcantabile_request: ...,
+  // ⚠️ SWcantabile_introduce 가 없어요!
+},
+```
+
+**왜 개선하면 좋을까?**
+이 상태로 `npm run build`를 하면 소개 페이지는 `dist/` 폴더에 포함되지 않아요.
+즉 **로컬에서는 잘 보이지만, 실제 배포하면 사라지는** 페이지가 돼버려요.
+나중에 “왜 안 보이지?” 하고 한참 찾게 되는 가장 흔한 실수예요.
+
+**추천:** `vite.config.js`에 한 줄을 추가해 주세요.
+
+```js
+SWcantabile_introduce: resolve(__dirname, 'src/SWcantabile/SWcantabile_introduce.html'),
+```
+
+---
+
+### 3-2. `<style>` 블록 안의 일반 CSS — Tailwind로 옮겨주세요 (중요도: 높음)
+
+**현재 상태:** 세 HTML 파일에 일반 CSS가 길게 들어가 있어요.
+
+```html
+<!-- SWcantabile_request.html (10 ~ 66 line) -->
+<style>
+  .video-area::after { ... }
+  .str_type.on { color: #e8371b; ... }
+  .accordion-body { display: none; }
+  .accordion-item.open .accordion-body { display: block; }
+  .pagination a.active { background-color: #dc2626; ... }
+</style>
+```
+
+```html
+<!-- SWcantabile_introduce.html (8 ~ 75 line) -->
+<style>
+  .swFirstSec .swContentInner { width: 100%; max-width: 100%; padding: 0 2rem; }
+  .swFirstSec .rounded-xl { opacity: 0; transform: translateY(20px); ... }
+  @keyframes fadeUp { ... }
+  .swTeamCard.swSlideLeft { transform: translateX(-40px); }
+  ...
+</style>
+```
+
+**왜 개선하면 좋을까?**
+프로젝트 컨벤션상 “**스타일은 Tailwind로, CSS는 정말 어쩔 수 없을 때만 최소한**”이에요.
+지금처럼 일반 CSS가 HTML 안에 흩어져 있으면 다음 문제가 생겨요.
+
+1. **결합도가 높아져요** — HTML과 CSS가 같은 파일에 들러붙어 있어, 다른 파일에서 같은 디자인을 재사용할 수 없어요.
+2. **다크 모드 변경이 두 곳에서 일어나요** — Tailwind 클래스에서도 `dark:`를 쓰는데 `<style>`에도 `.dark .str_type.on` 같은 게 또 있어서 헷갈려요.
+3. **유지보수가 어려워져요** — 색상 하나 바꾸려고 `<style>`도 보고 클래스도 봐야 해요.
+
+**추천:** 대부분은 Tailwind 한 줄로 바꿀 수 있어요.
+
+```html
+<!-- ❌ before -->
+<style>
+  .accordion-body { display: none; }
+  .accordion-item.open .accordion-body { display: block; }
+</style>
+<div class="accordion-body">...</div>
+
+<!-- ✅ after — Tailwind의 hidden + 자바스크립트 토글로 -->
+<div class="accordion-body hidden">...</div>
+<script>
+  // 클릭 시
+  body.classList.toggle('hidden');
+</script>
+```
+
+```html
+<!-- ❌ before -->
+<style>
+  .pagination a.active { background-color: #dc2626; color: #fff; ... }
+</style>
+
+<!-- ✅ after — JS에서 active일 때 클래스 추가 -->
+a.classList.add('bg-red-600', 'text-white', 'border-red-600', 'font-bold');
+```
+
+애니메이션(`@keyframes`)처럼 **정말 Tailwind로 표현하기 어려운 것만** 남기고 나머지는 모두 클래스로 옮겨 주세요.
+
+---
+
+### 3-3. `tempYoutubeUrls = song.url` — 필드 이름 오타 버그 (중요도: 높음)
+
+**현재 상태:** `admin_song_main.js` 134번째 줄
+
+```js
+editBtn.addEventListener('click', function () {
+  ...
+  document.getElementById('scoreInput').value = song.score;
+  // ⚠️ song.url 이 아니라 song.urls 가 맞아요
+  tempYoutubeUrls = song.url && Array.isArray(song.url) ? [...song.url] : [];
+  tempImageUrl = song.imageUrl || null;
+  ...
+});
+```
+
+다른 곳(139번째 줄, 242번째 줄)에서는 모두 `song.urls`(s가 붙은 복수형)를 쓰고 있어요.
+유독 이 한 줄만 단수형으로 잘못 쓰여 있어서, **수정 모드로 들어갔을 때 기존 유튜브 URL이 항상 빈 배열로 초기화**돼요.
+
+**왜 개선하면 좋을까?**
+사용자가 노래를 수정하려고 EDIT 버튼을 누르면, 기존에 등록된 유튜브 URL들이 사라진 것처럼 동작해요.
+그 상태로 저장하면 의도치 않게 URL이 손실될 수 있어요.
+
+**추천:**
+
+```js
+tempYoutubeUrls = Array.isArray(song.urls) ? song.urls.map((u) => u.url) : [];
+```
+
+(`song.urls`는 `[{ url, urlId }, ...]` 형태이므로 `.map((u) => u.url)`까지 해 주는 게 안전해요.)
+
+---
+
+### 3-4. `currentFilter`라는 “유령 변수” (중요도: 중간)
+
+**현재 상태:** `admin_song_main.js` 270번째 줄
+
+```js
+li.addEventListener('click', () => {
+  currentFilter = info.title;  // ⚠️ 어디에도 선언되지 않은 변수
+  if (info.title === '전체') { ... }
+});
+```
+
+`let`도 `const`도 없이 그냥 `currentFilter = ...`로 대입했어요. 이러면 자바스크립트는
+이 변수를 **전역(window.currentFilter)** 으로 만들어 버려요.
+그런데 다른 어디에서도 이 변수를 읽지 않아요. 그냥 “쓰기만 하고 아무도 안 읽는” 죽은 코드예요.
+
+**왜 개선하면 좋을까?**
+- 전역 변수가 늘어날수록 다른 페이지/스크립트와 이름이 충돌할 수 있어요.
+- 코드를 읽는 사람이 “이게 뭐지?” 하고 시간을 낭비해요.
+- `'use strict'` 환경에선 에러가 나요.
+
+**추천:** 그냥 그 줄을 **삭제**해 주세요. 정말 필요하면 `let currentFilter = '';`로 위에 선언하고 어떻게 쓰는지 명시해 주세요.
+
+---
+
+### 3-5. 가수 글자 수 안내가 50자가 아닌 20자에서 빨갛게 변해요 (중요도: 중간)
+
+**현재 상태:** `admin_song_main.js` 254 ~ 259번째 줄
+
+```js
+artistInput.addEventListener('input', () => {
+  const count = artistInput.value.length;
+  const el = document.getElementById('artistCount');
+  el.textContent = `${count} / 50`;
+  el.className = count >= 20 ? 'text-sm text-red-500 ...' : 'text-sm text-gray-400 ...';
+  //              ↑ 50이어야 하는데 20!
+});
+```
+
+HTML의 `maxlength="50"`과 안내 문구도 `0 / 50`인데, 빨간색으로 바뀌는 기준만 20이라 사용자가 헷갈려요.
+복붙하면서 숫자 바꾸는 걸 깜빡한 흔한 실수예요.
+
+**추천:**
+
+```js
+el.className = count >= 50 ? 'text-sm text-red-500 mt-1 text-right'
+                            : 'text-sm text-gray-400 mt-1 text-right';
+```
+
+---
+
+### 3-6. `viewport`의 `maximum-scale=1.0`은 빼주세요 (중요도: 중간)
+
+**현재 상태:** `SWcantabile_song.html`, `SWcantabile_request.html`
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+```
+
+**왜 개선하면 좋을까?**
+`maximum-scale=1.0`을 넣으면 모바일 사용자가 **두 손가락으로 화면을 확대(pinch-zoom)할 수 없어요**.
+시력이 약한 분들이 글씨를 크게 보고 싶을 때 막혀버려서 **접근성(WCAG)** 가이드라인 위반이에요.
+
+**추천:**
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+```
+
+---
+
+### 3-7. 사용 안 하는 “죽은 코드” (중요도: 중간)
+
+여러 곳에 “쓰이지 않는 코드”가 남아 있어요. 코드를 읽기 어렵게 만드는 주범이에요.
+
+**예시 1.** `SWcantabile_song.html` 25번째 줄
+```html
+<input type="hidden" id="strType" value="" />
+```
+`SWcantabile_song.js` 191번째 줄에서 `value`를 set만 하고, 어디서도 읽지 않아요. **삭제** 추천.
+
+**예시 2.** `admin_song_main.js`의 중복 클래스
+```js
+tdRank.className = ' font-bold  text-center font-bold text-gray-900 ...';
+//                   ↑ font-bold 가 두 번
+```
+공백도 두 칸씩 들어가 있어요. `font-bold`는 한 번만, 공백은 한 칸씩으로 정리해 주세요.
+
+**예시 3.** `admin_song_main.js` 184번째 줄
+```js
+await editSong(songs[editIndex].id, { songNo, title, artist, categoryId, score, imageUrl: tempImageUrl });
+```
+함수 인자가 너무 길어서 한눈에 안 들어와요. 객체로 미리 만들어 두면 더 깔끔해요.
+
+```js
+const payload = { songNo, title, artist, categoryId, score, imageUrl: tempImageUrl };
+await editSong(songs[editIndex].id, payload);
+```
+
+---
+
+### 3-8. `header.js` vs `sidebar.js` 실행 시점 일관성 (중요도: 중간)
+
+**현재 상태:**
+- `component/header.js`: 파일 끝에서 **즉시** `container.replaceWith(createHeader())` 실행
+- `admin/sidebar.js`: `document.addEventListener('DOMContentLoaded', () => { ... })`로 **나중에** 실행
+
+**왜 개선하면 좋을까?**
+같은 “컴포넌트 삽입” 코드인데 어떤 건 즉시, 어떤 건 DOMContentLoaded 후라 일관성이 깨져 있어요.
+초보 단계에서는 한 가지 패턴을 정해서 둘 다 같은 방식으로 만드는 게 “읽기 쉬운 코드”의 시작이에요.
+
+**추천 1. (간단)** 스크립트를 항상 `</body>` 직전에 두기로 약속하면, 둘 다 즉시 실행으로 통일해도 안전해요.
+
+```js
+// sidebar.js
+const container = document.getElementById('sidebar-container');
+if (container) {
+  container.replaceWith(createSidebar());
+}
+```
+
+**추천 2. (안전)** 또는 둘 다 `DOMContentLoaded`로 통일.
+
+둘 중 하나로 **약속**하는 게 핵심이에요.
+
+---
+
+### 3-9. `theme.js` — DOM이 없으면 에러 나요 (중요도: 중간)
+
+**현재 상태:** `component/theme.js` 3 ~ 5번째 줄
+
+```js
+const html = document.documentElement;
+const btn = document.getElementById('themeToggle');
+const icon = document.getElementById('themeIcon');
+const label = document.getElementById('themeLabel');
+...
+btn.addEventListener('click', () => ...);
+```
+
+`themeToggle`이 헤더 안에 있는데, 헤더가 아직 만들어지지 않았거나 페이지에 없으면
+`btn`이 `null`이라서 `btn.addEventListener`에서 오류가 나요.
+
+지금은 운 좋게 `header.js`가 즉시 헤더를 만들어 주기 때문에 동작해요. 하지만 header.js를 빼거나
+실행 시점을 바꾸면 **모든 페이지가 깨집니다.**
+
+**추천:** `null` 체크를 추가하거나, 헤더 컴포넌트 안에서 같이 처리하세요.
+
+```js
+if (!btn) return;  // 헤더가 없는 페이지면 그냥 종료
+btn.addEventListener('click', () => applyTheme(!html.classList.contains('dark'), true));
+```
+
+---
+
+### 3-10. `req.createdAt.split('T')[1].split('.')[0]`은 깨지기 쉬워요 (중요도: 중간)
+
+**현재 상태:** `admin/admin_request.js` 71번째 줄
+
+```js
+date.textContent = `신청 날짜: ${req.createdAt.split('T')[0]} 신청 시간: ${req.createdAt.split('T')[1].split('.')[0]}`;
+```
+
+서버가 보내주는 `createdAt`이 `2026-04-14T01:23:45.000Z` 같은 형식이 아니면
+`split('T')[1]`이 `undefined`가 되어 그 다음 `.split('.')`에서 에러가 나요.
+
+`SWcantabile_request.js`에서는 `formatDate()` 같은 헬퍼를 잘 만들어 두었어요. 똑같이 사용해 주세요.
+
+**추천:**
+
+```js
+function formatDateTime(iso) {
+  const d = new Date(iso);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())} ` +
+         `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+date.textContent = `신청 일시: ${formatDateTime(req.createdAt)}`;
+```
+
+`Date` 객체로 한 번 변환하면 형식이 조금 달라져도 자동으로 잘 처리돼요.
+
+---
+
+### 3-11. `admin_request.js`도 `esc()`로 보호해 주세요 (중요도: 중간)
+
+**현재 상태:** `admin_request.js`는 `textContent`를 사용해서 다행히 XSS는 안전해요.
+하지만 이건 “운 좋게 안전한” 거지, 의도해서 안전한 게 아니에요.
+
+만약 누군가 “스타일을 좀 강조해야지~” 하고 `innerHTML`로 살짝 바꾸면 그 즉시 보안 구멍이 됩니다.
+
+**추천:**
+- `SWcantabile/utils.js`의 `esc()`를 `src/component/utils.js`로 옮겨서 **모든 페이지가 함께 사용**하도록 해 주세요.
+- admin 쪽 코드도 `innerHTML`을 쓰는 부분이 생기면 반드시 `esc()`로 감싸주세요.
+
+```js
+// HTML
+<script src="../component/utils.js"></script>
+
+// JS — innerHTML 사용 시
+list.innerHTML = `<p>${esc(item.title)}</p>`;
+```
+
+---
+
+### 3-12. `admin_song_main.js`의 `onclick` vs `addEventListener` 혼용 (중요도: 낮음)
+
+**현재 상태:** 같은 파일에서 두 가지 방식을 섞어 쓰고 있어요.
+
+```js
+// 290번째 줄
+selectCategoryBtn.onclick = (e) => { ... };
+document.onclick = () => categoryDropdown.classList.add('hidden');
+
+// 다른 곳
+artImageInput.addEventListener('change', async () => { ... });
+saveSongBtn.addEventListener('click', async () => { ... });
+```
+
+**왜 개선하면 좋을까?**
+- `onclick = ...`은 한 요소에 **하나의 핸들러만** 등록할 수 있어요. 누군가 다른 곳에서 또 `onclick`을 쓰면 덮어쓰여요.
+- `addEventListener`는 여러 개를 안전하게 등록할 수 있어요.
+
+**추천:** 일관되게 `addEventListener`로 통일해 주세요.
+
+```js
+selectCategoryBtn.addEventListener('click', (e) => {
+  e.stopPropagation();
+  categoryDropdown.classList.toggle('hidden');
+});
+document.addEventListener('click', () => categoryDropdown.classList.add('hidden'));
+```
+
+---
+
+### 3-13. `category` 변수 이름 — 단수 vs 복수 (중요도: 낮음)
+
+**현재 상태:** `admin_category.js` 2번째 줄
+
+```js
+let category = [];   // ← 배열인데 단수형
+```
+
+배열에는 보통 복수형(`categories`)을 쓰는 게 관례예요. 단수형이면 “하나의 카테고리”인 줄 알고
+`category.title` 같은 실수를 하기 쉬워요.
+
+```js
+let categories = [];
+categories.forEach((item) => { ... });
+```
+
+---
+
+### 3-14. `SWcantabile_introduce.html`의 빈 `<span></span>` (중요도: 낮음)
+
+**현재 상태:** 92 ~ 102번째 줄
+
+```html
+<ul class="ul1">
+  <li><span></span></li>
+  <li><span></span></li>
+  ...
+</ul>
+```
+
+내용이 텅 빈 `<span>`이 들어 있어요. 아마 배경 이미지나 아이콘을 넣으려고 했던 것 같은데,
+그렇다면 **무엇을 보여주려는지 의도가 드러나도록** 클래스나 `aria-label`을 붙여 주세요.
+
+**추천:**
+
+```html
+<li><span class="block w-12 h-12 bg-[url('/icons/note.svg')] bg-cover" aria-hidden="true"></span></li>
+```
+
+(또는 차라리 `<img alt="">`를 쓰는 것이 더 명확해요.)
+
+---
+
+### 3-15. “관리자 전용” 제목과 버튼 — 시맨틱 요소 사용 (중요도: 낮음)
+
+**현재 상태:** `SWcantabile_introduce.html` 84 ~ 89번째 줄
+
+```html
+<div class="swIntoTitle">
+  <h1>
+    <span>노래하는 즐거움,</span>
+    <span><em>SW</em>가 만들어갑니다</span>
+  </h1>
+</div>
+```
+
+`<h1>` 안에 의미 없는 `<em>`이 “장식 목적”으로 쓰였어요. `<em>`은 **강조의 의미**가 있는 태그라
+스크린리더가 “SW”를 강조해서 읽어줘요. 디자인 목적이라면 `<span class="text-red-600">`이 더 적합해요.
+
+```html
+<h1>
+  노래하는 즐거움,
+  <br />
+  <span class="text-red-600">SW</span>가 만들어갑니다
+</h1>
+```
+
+---
+
+### 3-16. CSS 한 곳, 한 번만! — 인라인 `style="..."`도 줄여요 (중요도: 낮음)
+
+**현재 상태:** `SWcantabile_song.html`에 인라인 `style`이 종종 보여요.
+
+```html
+<button ... style="${s.urls && s.urls.length ? '' : 'opacity:0.3'}">
+<div class="relative w-full" style="padding-bottom:56.25%">
+```
+
+**추천:** Tailwind 값을 활용해 보세요.
+
+```html
+<button class="... ${s.urls && s.urls.length ? '' : 'opacity-30'}">
+<div class="relative w-full pb-[56.25%]">
+```
+
+Tailwind는 `pb-[56.25%]`처럼 **임의의 값**도 대괄호로 받을 수 있어요.
+
+---
+
+## 4. 파일별 요약
+
+| 파일 | 완성도 | 주요 피드백 |
+|------|:---:|------|
+| `vite.config.js` | 90% | introduce.html 입력 누락 |
+| `src/component/header.js` | 95% | 잘 분리됨 (☆) |
+| `src/component/theme.js` | 80% | DOM 존재 체크 필요 |
+| `src/component/api-config.js` | 100% | 단순·명료 (☆) |
+| `src/SWcantabile/SWcantabile_song.html` | 85% | viewport, dead code, 인라인 style |
+| `src/SWcantabile/SWcantabile_song.js` | 90% | 잘 작성됨 |
+| `src/SWcantabile/SWcantabile_request.html` | 70% | `<style>` 블록을 Tailwind로 |
+| `src/SWcantabile/SWcantabile_request.js` | 90% | 잘 작성됨 (esc 활용 ☆) |
+| `src/SWcantabile/SWcantabile_introduce.html` | 65% | `<style>` 큰 덩어리, 빌드 미등록 |
+| `src/SWcantabile/utils.js` | 95% | component로 옮겨도 좋음 |
+| `src/admin/admin_song.html` | 90% | 잘 작성됨 |
+| `src/admin/admin_song/admin_song_api.js` | 95% | 분리 잘됨 (☆) |
+| `src/admin/admin_song/admin_song_main.js` | 75% | `song.url` 오타, count 20, 죽은 변수 |
+| `src/admin/admin_category.js` | 85% | 변수명, 분리 권장 |
+| `src/admin/admin_request.js` | 80% | 날짜 파싱, esc 미사용 |
+| `src/admin/sidebar.js` | 95% | 잘 작성됨 (☆) |
+| `src/admin/auth.js` | 100% | 단순·명료 (☆) |
+
+---
+
+## 5. 다음 단계 제안
+
+이번 리뷰를 정리해 보면, 우선순위는 이렇게 잡으면 좋아요.
+
+1. **(빌드 깨짐 위험)** `vite.config.js`에 `SWcantabile_introduce` 등록 → 5분
+2. **(데이터 손실 위험)** `admin_song_main.js`의 `song.url` → `song.urls` 수정 → 5분
+3. **(접근성)** `viewport`의 `maximum-scale=1.0` 제거 → 2분
+4. **(소소한 버그)** 가수 글자 수 빨간색 기준 20 → 50 → 2분
+5. **(컨벤션 통일)** `<style>` 블록의 일반 CSS를 Tailwind 클래스로 옮기기 → 1 ~ 2시간
+6. **(코드 품질)** 죽은 변수/dead code 정리, 변수명 정리 → 30분
+7. **(구조 개선)** `utils.js`를 `component/`로 옮기고 admin도 같이 사용 → 20분
+8. **(추가 분리)** `admin_category`, `admin_request`도 `_api.js` / `_main.js`로 분리 → 1시간
+
+**뇌가 고침 → 바로 효과**가 큰 것부터 차례로 처리해 보세요!
+
+---
+
+## 6. 마무리
+
+이전 리뷰에서 “이런 부분 고쳐보자!” 했던 항목들을 거의 다 깔끔하게 해결했어요.
+특히 **컴포넌트 분리(`component/`, `sidebar.js`)** 와 **API/UI 분리(`admin_song/`)** 는
+실무에서도 중요한 패턴이에요. 이 사고방식을 익혔다는 것만으로도 큰 발전이에요. 👏
+
+이제는 **일관성**과 **세심한 디테일**이 다음 단계예요.
+같은 일을 두 가지 방식으로 하지 않기, 죽은 코드는 바로 지우기, 변수는 의미 있는 이름으로 짓기 —
+이런 작은 습관이 모이면 어느새 “읽기 좋은 코드”가 돼요.
+
+`reviews/2026041410_리뷰_해결.md`에 **복사해서 바로 붙여넣을 수 있는** 해결 코드를 정리해 두었어요.
+하나씩 따라 해보면 금방 끝낼 수 있어요. 화이팅! 🎉

--- a/reviews/2026041410_리뷰_해결.md
+++ b/reviews/2026041410_리뷰_해결.md
@@ -1,0 +1,652 @@
+# 리뷰 해결 가이드 (8차)
+
+> 리뷰 날짜: 2026-04-14
+> 대상: rawbeef 프로젝트 (SW칸타빌레)
+> 원본 리뷰: [2026041410_리뷰.md](./2026041410_리뷰.md)
+> 이전 해결 가이드: [2026033010_리뷰_해결.md](./2026033010_리뷰_해결.md)
+
+이 문서는 **위에서부터 순서대로** 따라 하면 되도록 정리했어요.
+각 항목 끝에 “쉽게 말하면” 비유가 있으니, **왜 이렇게 고치는지** 같이 익혀 주세요.
+
+---
+
+## 3-1. `SWcantabile_introduce.html`을 빌드 설정에 추가 (중요도: 높음)
+
+### 문제
+
+`vite.config.js`의 `input` 객체에 신규 페이지가 빠져 있어서, 빌드 시 `dist/`에 포함되지 않아요.
+
+### 해결 방법
+
+**Step 1.** `vite.config.js`를 열어서 `SWcantabile_request` 다음 줄에 한 줄 추가하세요.
+
+```js
+// 수정 전 (vite.config.js 8 ~ 17번째 줄)
+input: {
+  main: resolve(__dirname, 'index.html'),
+  admin_open: resolve(__dirname, 'src/admin/admin_open.html'),
+  admin_category: resolve(__dirname, 'src/admin/admin_category.html'),
+  admin_song: resolve(__dirname, 'src/admin/admin_song.html'),
+  admin_request: resolve(__dirname, 'src/admin/admin_request.html'),
+  SWcantabile_song: resolve(__dirname, 'src/SWcantabile/SWcantabile_song.html'),
+  SWcantabile_request: resolve(__dirname, 'src/SWcantabile/SWcantabile_request.html'),
+},
+
+// 수정 후
+input: {
+  main: resolve(__dirname, 'index.html'),
+  admin_open: resolve(__dirname, 'src/admin/admin_open.html'),
+  admin_category: resolve(__dirname, 'src/admin/admin_category.html'),
+  admin_song: resolve(__dirname, 'src/admin/admin_song.html'),
+  admin_request: resolve(__dirname, 'src/admin/admin_request.html'),
+  SWcantabile_song: resolve(__dirname, 'src/SWcantabile/SWcantabile_song.html'),
+  SWcantabile_request: resolve(__dirname, 'src/SWcantabile/SWcantabile_request.html'),
+  SWcantabile_introduce: resolve(__dirname, 'src/SWcantabile/SWcantabile_introduce.html'),
+},
+```
+
+**Step 2.** 터미널에서 `npm run build`로 확인해 보세요. `dist/src/SWcantabile/SWcantabile_introduce.html`이 생기면 성공이에요.
+
+> **쉽게 말하면:** 손님 명단(빌드 입력)에 새 친구(introduce 페이지)를 추가하지 않으면 파티(배포)에 못 와요.
+
+---
+
+## 3-2. `<style>` 블록을 Tailwind로 옮기기 (중요도: 높음)
+
+### 문제
+
+`SWcantabile_request.html`(10 ~ 66번째 줄)과 `SWcantabile_introduce.html`(8 ~ 75번째 줄)에
+일반 CSS가 길게 들어가 있어요. 프로젝트 컨벤션은 “Tailwind 우선, CSS는 최소”예요.
+
+### 해결 방법
+
+#### A. `SWcantabile_request.html` 정리
+
+**Step 1.** 아코디언을 Tailwind만으로 처리하기.
+
+```html
+<!-- 수정 전 (SWcantabile_request.html 41 ~ 53번째 줄) -->
+<style>
+  .accordion-body { display: none; }
+  .accordion-item.open .accordion-body { display: block; }
+  .accordion-item.open .accordion-arrow { transform: rotate(180deg); }
+  .accordion-arrow { transition: transform 0.2s ease; }
+</style>
+
+<!-- 수정 후 — <style>에서 위 4개 규칙 삭제 -->
+```
+
+**Step 2.** `SWcantabile_request.js`의 `accordion-body`와 `accordion-arrow` 클래스에 Tailwind 직접 추가.
+
+```js
+// 수정 전 (SWcantabile_request.js 72번째 줄 부근)
+<div class="accordion-body bg-gray-50 ...">
+
+// 수정 후
+<div class="accordion-body hidden bg-gray-50 ...">
+```
+
+```js
+// 수정 전 (SWcantabile_request.js 65번째 줄 부근)
+<svg class="accordion-arrow w-3.5 h-3.5 ..." ...>
+
+// 수정 후
+<svg class="accordion-arrow w-3.5 h-3.5 transition-transform duration-200 ..." ...>
+```
+
+**Step 3.** 토글 로직을 “클래스 추가/제거”로 교체.
+
+```js
+// 수정 전 (SWcantabile_request.js 144 ~ 147번째 줄)
+el.querySelector('.accordion-trigger').addEventListener('click', () => {
+  const isOpen = el.classList.contains('open');
+  el.classList.toggle('open', !isOpen);
+});
+
+// 수정 후
+el.querySelector('.accordion-trigger').addEventListener('click', () => {
+  const body = el.querySelector('.accordion-body');
+  const arrow = el.querySelector('.accordion-arrow');
+  body.classList.toggle('hidden');
+  arrow.classList.toggle('rotate-180');
+});
+```
+
+**Step 4.** 페이지네이션 active 스타일도 클래스 추가 방식으로.
+
+```js
+// 수정 전 (SWcantabile_request.js 224 ~ 227번째 줄)
+for (let i = groupStart; i <= groupEnd; i++) {
+  const a = makePagBtn(String(i), i);
+  if (i === page) a.classList.add('active');
+  wrap.appendChild(a);
+}
+
+// 수정 후
+for (let i = groupStart; i <= groupEnd; i++) {
+  const a = makePagBtn(String(i), i);
+  if (i === page) {
+    a.classList.add('bg-red-600', 'text-white', 'border-red-600', 'font-bold',
+                    'dark:bg-red-500', 'dark:border-red-500');
+  }
+  wrap.appendChild(a);
+}
+```
+
+**Step 5.** `SWcantabile_request.html`의 `.pagination`, `.str_type`, `.video-area::after` CSS 규칙을 모두 삭제.
+대신 `.video-area`에 직접 Tailwind 클래스를 추가하세요.
+
+```html
+<!-- 수정 전 (SWcantabile_request.html 74번째 줄) -->
+<div class="video-area relative w-full min-h-48 bg-gray-900 dark:bg-black flex items-center px-10 py-12 overflow-hidden">
+
+<!-- 수정 후 — after: 의사 요소를 Tailwind로 -->
+<div class="relative w-full min-h-48 bg-gray-900 dark:bg-black flex items-center px-10 py-12 overflow-hidden after:content-[''] after:absolute after:inset-0 after:bg-linear-to-br after:from-black/70 after:to-gray-800/40">
+```
+
+이렇게 하면 `<style>` 블록 전체를 **삭제**할 수 있어요.
+
+#### B. `SWcantabile_introduce.html` 정리
+
+**Step 1.** 애니메이션은 Tailwind의 `animate-*`나 `transition` 으로 충분히 표현 가능해요.
+간단한 fade-up은 다음 CSS 한 줄만 남기고 나머지는 모두 Tailwind로 옮기세요.
+
+```html
+<!-- 수정 전 (SWcantabile_introduce.html 8 ~ 75번째 줄 전체) -->
+<style>
+  .swFirstSec .swContentInner { width: 100%; max-width: 100%; padding: 0 2rem; }
+  ...많은 규칙...
+</style>
+
+<!-- 수정 후 — 정말 keyframes만 남기기 -->
+<style>
+  @keyframes fadeUp { to { opacity: 1; transform: translateY(0); } }
+  @keyframes swSlideIn { to { opacity: 1; transform: translateX(0); } }
+  @keyframes swSlideInRight { to { opacity: 1; transform: translateX(0); } }
+</style>
+```
+
+**Step 2.** `swContentInner`, `swTeamList` 같은 클래스는 div에 직접 Tailwind를 적어 주세요.
+
+```html
+<!-- 수정 전 -->
+<div class="swContentInner">
+
+<!-- 수정 후 -->
+<div class="w-full max-w-full px-8">
+```
+
+**Step 3.** 카드 등장 애니메이션은 nth-child 대신 인라인 `style="animation-delay"`로 대체.
+
+```html
+<!-- 수정 전 — CSS의 nth-child로 처리 -->
+.swFirstSec .rounded-xl:nth-child(1) { animation-delay: 0.1s; }
+.swFirstSec .rounded-xl:nth-child(2) { animation-delay: 0.2s; }
+...
+
+<!-- 수정 후 — 카드별 인라인 스타일로 직접 지정 -->
+<div class="rounded-xl ... opacity-0 [animation:fadeUp_0.5s_ease_forwards]" style="animation-delay:0.1s">
+<div class="rounded-xl ... opacity-0 [animation:fadeUp_0.5s_ease_forwards]" style="animation-delay:0.2s">
+```
+
+> **쉽게 말하면:** 도구함이 두 개(Tailwind + CSS)면 똑같은 망치를 두 개 들고 다니는 셈이에요. 하나만 골라서 일관되게 쓰는 게 “좋은 코드”의 첫걸음이에요.
+
+---
+
+## 3-3. `tempYoutubeUrls = song.url` → `song.urls` (중요도: 높음)
+
+### 문제
+
+`admin_song_main.js` 134번째 줄에서 필드 이름이 `song.url`로 잘못 적혀 있어, 노래 수정 시 기존 유튜브 URL이 사라져요.
+
+### 해결 방법
+
+**Step 1.**
+
+```js
+// 수정 전 (admin_song_main.js 134번째 줄)
+tempYoutubeUrls = song.url && Array.isArray(song.url) ? [...song.url] : [];
+
+// 수정 후
+tempYoutubeUrls = Array.isArray(song.urls) ? song.urls.map((u) => u.url) : [];
+```
+
+`song.urls`는 `[{ url: '...', urlId: 1 }, ...]` 형태이므로, **문자열만** 뽑기 위해 `.map((u) => u.url)`을 추가했어요.
+
+**Step 2.** 동작 확인 — 기존 노래의 EDIT 버튼을 누르고, 모달을 닫지 말고 “저장”을 눌러보세요. 기존 유튜브 URL이 그대로 유지되어야 해요.
+
+> **쉽게 말하면:** 컴퓨터한테 “노래의 url(단수)”를 가져오라고 시켰는데, 실제 데이터는 “urls(복수)”라는 이름이라 “그런 거 없는데?” 하고 빈손으로 돌아왔던 거예요. 이름표 한 글자 차이!
+
+---
+
+## 3-4. `currentFilter` 죽은 변수 삭제 (중요도: 중간)
+
+### 문제
+
+`admin_song_main.js` 270번째 줄에서 선언 없이 변수에 값을 대입해 전역 변수가 되고 있어요. 어디서도 읽지 않는 죽은 코드예요.
+
+### 해결 방법
+
+**Step 1.** 그냥 해당 줄을 삭제하세요.
+
+```js
+// 수정 전 (admin_song_main.js 269 ~ 270번째 줄)
+li.addEventListener('click', () => {
+  currentFilter = info.title;
+  if (info.title === '전체') {
+
+// 수정 후
+li.addEventListener('click', () => {
+  if (info.title === '전체') {
+```
+
+> **쉽게 말하면:** 책상 위에 “나중에 쓸지도 몰라!” 하면서 안 쓰는 메모지를 잔뜩 두면 정작 필요한 메모를 못 찾아요. 안 쓰는 건 바로 버리는 게 깔끔해요.
+
+---
+
+## 3-5. 가수 글자 수 빨간색 기준 20 → 50 (중요도: 중간)
+
+### 문제
+
+`maxlength="50"`인데 빨간색 안내는 20자에서 시작해서 사용자가 “20자 넘었는데 왜 입력은 더 되지?” 하고 헷갈려요.
+
+### 해결 방법
+
+```js
+// 수정 전 (admin_song_main.js 254 ~ 259번째 줄)
+artistInput.addEventListener('input', () => {
+  const count = artistInput.value.length;
+  const el = document.getElementById('artistCount');
+  el.textContent = `${count} / 50`;
+  el.className = count >= 20 ? 'text-sm text-red-500 mt-1 text-right' : 'text-sm text-gray-400 mt-1 text-right';
+});
+
+// 수정 후
+artistInput.addEventListener('input', () => {
+  const count = artistInput.value.length;
+  const el = document.getElementById('artistCount');
+  el.textContent = `${count} / 50`;
+  el.className = count >= 50 ? 'text-sm text-red-500 mt-1 text-right' : 'text-sm text-gray-400 mt-1 text-right';
+});
+```
+
+> **쉽게 말하면:** “주의! 한도는 50인데 빨간 신호등은 20에서 켜진 셈”이에요. 신호등 위치를 50으로 옮겨 주는 거예요.
+
+---
+
+## 3-6. `viewport`의 `maximum-scale=1.0` 제거 (중요도: 중간)
+
+### 문제
+
+모바일 사용자가 손가락으로 화면을 확대할 수 없어 접근성 위반이에요.
+
+### 해결 방법
+
+**Step 1.** 두 파일을 같은 방식으로 수정하세요.
+
+```html
+<!-- 수정 전 (SWcantabile_song.html 6번째 줄) -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+
+<!-- 수정 후 -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+```
+
+```html
+<!-- 수정 전 (SWcantabile_request.html 6번째 줄) -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+
+<!-- 수정 후 -->
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+```
+
+> **쉽게 말하면:** 사용자에게 “돋보기 사용 금지!”라고 해 둔 셈이에요. 누구나 자유롭게 확대해서 볼 수 있게 해 주세요.
+
+---
+
+## 3-7. 죽은 코드와 중복 클래스 정리 (중요도: 중간)
+
+### 문제
+
+쓰이지 않는 input과 중복된 Tailwind 클래스가 코드 곳곳에 있어요.
+
+### 해결 방법
+
+**Step 1.** `SWcantabile_song.html`의 사용 안 하는 hidden input 삭제.
+
+```html
+<!-- 수정 전 (SWcantabile_song.html 25번째 줄) -->
+<input type="hidden" id="strType" value="" />
+
+<!-- 수정 후 — 줄 자체를 삭제 -->
+```
+
+**Step 2.** `SWcantabile_song.js`에서 그 input을 set하는 줄도 삭제.
+
+```js
+// 수정 전 (SWcantabile_song.js 191번째 줄)
+async function setStrType(type, id, el) {
+  document.getElementById('strType').value = type;
+  document.querySelectorAll('.str_type').forEach((a) => a.classList.remove('on'));
+
+// 수정 후
+async function setStrType(type, id, el) {
+  document.querySelectorAll('.str_type').forEach((a) => a.classList.remove('on'));
+```
+
+**Step 3.** `admin_song_main.js`의 중복 `font-bold` 정리.
+
+```js
+// 수정 전 (admin_song_main.js 70 ~ 99번째 줄 부근)
+tdRank.className = ' font-bold  text-center font-bold text-gray-900 dark:text-gray-100';
+tdSongNo.className = '  font-bold text-center font-bold text-gray-900 dark:text-gray-100';
+tdArtImage.className = '  font-bold text-center font-bold text-gray-900 dark:text-gray-100';
+tdTitle.className = '  font-bold  text-center font-bold text-gray-900 dark:text-gray-100';
+tdCategory.className = 'font-bold text-center font-bold text-gray-900 dark:text-gray-100';
+tdArtist.className = '  font-bold  text-center font-bold text-gray-900 dark:text-gray-100';
+
+// 수정 후 — 한 번씩만, 깔끔하게
+const tdBaseClass = 'font-bold text-center text-gray-900 dark:text-gray-100';
+tdRank.className = tdBaseClass;
+tdSongNo.className = tdBaseClass;
+tdArtImage.className = tdBaseClass;
+tdTitle.className = tdBaseClass;
+tdCategory.className = tdBaseClass;
+tdArtist.className = tdBaseClass;
+```
+
+> **쉽게 말하면:** 같은 말을 두 번 외치면 듣는 사람 입장에선 메아리예요. 한 번만, 정확하게.
+
+---
+
+## 3-8. `header.js` ↔ `sidebar.js` 실행 시점 통일 (중요도: 중간)
+
+### 문제
+
+header는 즉시 실행, sidebar는 DOMContentLoaded 후 실행. 일관성이 없어요.
+
+### 해결 방법
+
+**Step 1.** `sidebar.js`를 즉시 실행 방식으로 바꾸세요.
+
+```js
+// 수정 전 (admin/sidebar.js 43 ~ 48번째 줄)
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('sidebar-container');
+  if (container) {
+    container.replaceWith(createSidebar());
+  }
+});
+
+// 수정 후
+const container = document.getElementById('sidebar-container');
+if (container) {
+  container.replaceWith(createSidebar());
+}
+```
+
+**전제 조건:** `admin_song.html`에서 `<script src="./sidebar.js"></script>`가
+`<div id="sidebar-container"></div>` **다음 줄**에 와야 해요. 지금 이미 그렇게 돼 있으니 안전해요.
+
+> **쉽게 말하면:** “집을 짓고 나서 가구 들이기”와 “집 짓기 끝나면 바로 가구 들이기”는 결과는 같지만, 약속을 하나로 정해야 다음 사람도 헷갈리지 않아요.
+
+---
+
+## 3-9. `theme.js` null 체크 (중요도: 중간)
+
+### 문제
+
+`themeToggle` DOM이 없으면 `addEventListener`에서 에러가 나요.
+
+### 해결 방법
+
+```js
+// 수정 전 (component/theme.js 1 ~ 25번째 줄)
+const html = document.documentElement;
+const btn = document.getElementById('themeToggle');
+const icon = document.getElementById('themeIcon');
+const label = document.getElementById('themeLabel');
+
+function applyTheme(dark, save = false) {
+  if (dark) {
+    html.classList.add('dark');
+    icon.textContent = '☀️';
+    label.textContent = '라이트 모드';
+  } else {
+    html.classList.remove('dark');
+    icon.textContent = '🌙';
+    label.textContent = '다크 모드';
+  }
+  if (save) localStorage.setItem('theme', dark ? 'dark' : 'light');
+}
+
+const saved = localStorage.getItem('theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+applyTheme(saved ? saved === 'dark' : prefersDark);
+
+btn.addEventListener('click', () => applyTheme(!html.classList.contains('dark'), true));
+
+// 수정 후
+const html = document.documentElement;
+const btn = document.getElementById('themeToggle');
+const icon = document.getElementById('themeIcon');
+const label = document.getElementById('themeLabel');
+
+function applyTheme(dark, save = false) {
+  if (dark) {
+    html.classList.add('dark');
+    if (icon) icon.textContent = '☀️';
+    if (label) label.textContent = '라이트 모드';
+  } else {
+    html.classList.remove('dark');
+    if (icon) icon.textContent = '🌙';
+    if (label) label.textContent = '다크 모드';
+  }
+  if (save) localStorage.setItem('theme', dark ? 'dark' : 'light');
+}
+
+const saved = localStorage.getItem('theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+applyTheme(saved ? saved === 'dark' : prefersDark);
+
+if (btn) {
+  btn.addEventListener('click', () => applyTheme(!html.classList.contains('dark'), true));
+}
+```
+
+> **쉽게 말하면:** “이 사람 만나면 인사해!”라고 했는데 그 사람이 안 왔으면 어떡해요? “있으면 인사하고, 없으면 그냥 패스!”가 안전해요.
+
+---
+
+## 3-10. `admin_request.js` 날짜 파싱 (중요도: 중간)
+
+### 문제
+
+`req.createdAt.split('T')[1].split('.')[0]`는 createdAt 형식이 조금만 달라져도 깨져요.
+
+### 해결 방법
+
+**Step 1.** 헬퍼 함수를 파일 위쪽에 추가하세요.
+
+```js
+// admin_request.js 맨 위(let requests = []; 다음)에 추가
+function formatDateTime(iso) {
+  const d = new Date(iso);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}.${pad(d.getMonth() + 1)}.${pad(d.getDate())} ` +
+         `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+```
+
+**Step 2.** 71번째 줄 부근의 date 텍스트를 교체.
+
+```js
+// 수정 전 (admin_request.js 70 ~ 71번째 줄)
+date.className = 'text-m font-bold mb-2 text-center text-gray-900 dark:text-white';
+date.textContent = `신청 날짜: ${req.createdAt.split('T')[0]} 신청 시간: ${req.createdAt.split('T')[1].split('.')[0]}`;
+
+// 수정 후
+date.className = 'text-sm font-bold mb-2 text-center text-gray-900 dark:text-white';
+date.textContent = `신청 일시: ${formatDateTime(req.createdAt)}`;
+```
+
+> **쉽게 말하면:** 글자 위치를 “3번째 글자, 5번째 글자” 식으로 자르면, 글자 길이가 달라지면 와르르 무너져요. `Date` 객체로 한 번 변환하면 알아서 잘 처리해 줘요.
+
+---
+
+## 3-11. `utils.js`를 공통 위치로 이동 (중요도: 중간)
+
+### 문제
+
+`esc()`는 보안 관점에서 모든 페이지가 함께 써야 하는데, 지금은 `SWcantabile/utils.js`에만 있어요.
+
+### 해결 방법
+
+**Step 1.** 파일 이동.
+
+```bash
+git mv src/SWcantabile/utils.js src/component/utils.js
+```
+
+**Step 2.** SWcantabile HTML에서 경로 변경.
+
+```html
+<!-- 수정 전 (SWcantabile_song.html 136번째 줄) -->
+<script src="./utils.js"></script>
+
+<!-- 수정 후 -->
+<script src="../component/utils.js"></script>
+```
+
+`SWcantabile_request.html` 160번째 줄도 같은 방식으로 수정.
+
+**Step 3.** admin HTML에도 추가.
+
+```html
+<!-- admin_song.html, admin_category.html, admin_request.html, admin_open.html -->
+<script src="../component/api-config.js"></script>
+<script src="../component/utils.js"></script>   <!-- 이 줄 추가 -->
+```
+
+**Step 4.** admin_request.js 등에서 innerHTML이 생기면 `esc()`로 감싸는 습관 들이기.
+
+> **쉽게 말하면:** 안전 장갑(esc 함수)을 한 명만 가지고 있으면 다른 사람이 다칠 수 있어요. 모두 같이 쓰는 공구함(component)에 두면 누구나 손쉽게 끼워요.
+
+---
+
+## 3-12. `onclick`을 `addEventListener`로 통일 (중요도: 낮음)
+
+### 해결 방법
+
+```js
+// 수정 전 (admin_song_main.js 290 ~ 295번째 줄)
+selectCategoryBtn.onclick = (e) => {
+  e.stopPropagation();
+  categoryDropdown.classList.toggle('hidden');
+};
+
+document.onclick = () => categoryDropdown.classList.add('hidden');
+
+// 수정 후
+selectCategoryBtn.addEventListener('click', (e) => {
+  e.stopPropagation();
+  categoryDropdown.classList.toggle('hidden');
+});
+
+document.addEventListener('click', () => {
+  categoryDropdown.classList.add('hidden');
+});
+```
+
+> **쉽게 말하면:** `onclick`은 “화이트보드 위에 글씨 한 줄” — 누가 그 위에 다시 쓰면 사라져요. `addEventListener`는 “포스트잇” — 여러 장 붙일 수 있어요.
+
+---
+
+## 3-13. `category` → `categories` 변수명 (중요도: 낮음)
+
+### 해결 방법
+
+```js
+// 수정 전 (admin_category.js 2번째 줄)
+let category = [];
+...
+category = json.data;
+...
+category.forEach((item, index) => {
+
+// 수정 후 — 파일 전체에서 category → categories 로 일괄 변경
+let categories = [];
+...
+categories = json.data;
+...
+categories.forEach((item, index) => {
+```
+
+VS Code의 “Rename Symbol(F2)” 또는 “Find & Replace(Cmd+D)”를 활용하면 빠르게 바꿀 수 있어요.
+
+> **쉽게 말하면:** “사과” 한 개와 “사과들” 한 봉지는 다르잖아요? 변수 이름만 봐도 무엇이 들어 있는지 알 수 있어야 해요.
+
+---
+
+## 3-14 ~ 3-16. 가벼운 정리
+
+### 3-14. 빈 `<span>`에 의도 표시
+```html
+<!-- 수정 전 -->
+<li><span></span></li>
+
+<!-- 수정 후 — 의미 있는 클래스나 aria-hidden -->
+<li><span class="block w-full h-full" aria-hidden="true"></span></li>
+```
+
+### 3-15. 장식 목적의 `<em>`은 `<span>`으로
+```html
+<!-- 수정 전 -->
+<h1>
+  <span>노래하는 즐거움,</span>
+  <span><em>SW</em>가 만들어갑니다</span>
+</h1>
+
+<!-- 수정 후 -->
+<h1>
+  <span>노래하는 즐거움,</span>
+  <span><span class="text-red-600">SW</span>가 만들어갑니다</span>
+</h1>
+```
+
+### 3-16. 인라인 style → Tailwind 임의 값
+```html
+<!-- 수정 전 -->
+<button style="${s.urls && s.urls.length ? '' : 'opacity:0.3'}">
+<div class="relative w-full" style="padding-bottom:56.25%">
+
+<!-- 수정 후 -->
+<button class="${s.urls && s.urls.length ? '' : 'opacity-30'}">
+<div class="relative w-full pb-[56.25%]">
+```
+
+---
+
+## 수정 우선순위 체크리스트
+
+순서대로 따라 하면 30분 안에 핵심을 다 잡을 수 있어요.
+
+| 순서 | 항목 | 난이도 | 예상 시간 |
+|:---:|---|:---:|:---:|
+| 1 | `vite.config.js` introduce 등록 (3-1) | 쉬움 | 2분 |
+| 2 | `song.url` → `song.urls` 오타 수정 (3-3) | 쉬움 | 2분 |
+| 3 | viewport `maximum-scale` 제거 (3-6) | 쉬움 | 2분 |
+| 4 | 가수 글자 수 20 → 50 (3-5) | 쉬움 | 1분 |
+| 5 | `currentFilter` 죽은 변수 삭제 (3-4) | 쉬움 | 1분 |
+| 6 | `theme.js` null 체크 (3-9) | 쉬움 | 5분 |
+| 7 | hidden input·중복 클래스 정리 (3-7) | 쉬움 | 10분 |
+| 8 | `admin_request.js` 날짜 파싱 (3-10) | 보통 | 10분 |
+| 9 | `category` → `categories` 변수명 (3-13) | 쉬움 | 5분 |
+| 10 | `onclick` → `addEventListener` (3-12) | 쉬움 | 5분 |
+| 11 | `sidebar.js` 실행 시점 통일 (3-8) | 보통 | 5분 |
+| 12 | `utils.js` 공통 위치 이동 (3-11) | 보통 | 15분 |
+| 13 | 인라인 style → Tailwind (3-16) | 보통 | 20분 |
+| 14 | `<style>` 블록 → Tailwind 옮기기 (3-2) | 도전 | 1 ~ 2시간 |
+
+> 윗줄부터 차례차례 해 보세요.
+> **막히는 부분은 절대 혼자 끙끙대지 말고** 강사님이나 동료에게 물어보세요. 모르는 걸 묻는 것도 실력이에요. 화이팅! 💪


### PR DESCRIPTION
## Summary
- `src/component`, `src/SWcantabile`, `src/admin` 재구조화 이후 첫 리뷰
- 신규 페이지 `SWcantabile_introduce.html`을 포함한 전체 코드 리뷰 결과 정리
- 학생 친화적 해결 가이드 문서 동봉

## 이번 리뷰의 핵심
**높은 중요도 (지금 바로 고쳐야 할 것)**
1. `vite.config.js`에 `SWcantabile_introduce` 입력 누락 → 배포 시 페이지 누락
2. `admin_song_main.js`의 `song.url` → `song.urls` 오타 → 노래 수정 시 유튜브 URL 손실
3. `<style>` 블록 안의 일반 CSS → Tailwind로 옮기기 (컨벤션 준수)

**중간 중요도**
- viewport `maximum-scale=1.0` 제거(접근성)
- `currentFilter` 미선언 전역 변수 / 가수 글자 수 임계값 20→50 / 죽은 코드 정리
- `theme.js` null 체크, `header.js`/`sidebar.js` 실행 시점 통일
- `admin_request.js`의 `split('T')` 날짜 파싱 → `Date` 객체 사용
- `utils.js`(`esc()`)를 `component/`로 이동해 admin도 함께 사용

**낮은 중요도**
- `onclick` → `addEventListener` 일관화
- `category` → `categories` 변수명 / 빈 `<span>` / 인라인 `style` 정리

## 잘한 점
- 컴포넌트 분리 (`component/header.js`, `sidebar.js`, `theme.js`)
- API/UI 분리 (`admin_song_api.js` ↔ `admin_song_main.js`)
- `esc()`를 활용한 XSS 방지 습관
- URL 파라미터로 카테고리 상태 공유

## 문서
- [reviews/2026041410_리뷰.md](./reviews/2026041410_리뷰.md)
- [reviews/2026041410_리뷰_해결.md](./reviews/2026041410_리뷰_해결.md)

## Test plan
- [ ] 학생들이 해결 가이드를 따라가며 핵심 버그 3건(3-1, 3-3, 3-6)을 수정해 본다
- [ ] `npm run build` 후 `dist/`에 introduce 페이지가 포함되는지 확인
- [ ] 노래 EDIT 모드 진입 시 기존 유튜브 URL이 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)